### PR TITLE
(potentially) fix theme switch flash on websites using ThemeSwitch component

### DIFF
--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -52,18 +52,6 @@ const { label, class: className } = Astro.props
     color: rgb(var(--ac-color-700));
     font-size: var(--ac-text-sm);
 
-    &:has([aria-checked='true']) {
-      .ac-theme-switch-icon--dark {
-        display: none;
-      }
-    }
-
-    &:has([aria-checked='false']) {
-      .ac-theme-switch-icon--light {
-        display: none;
-      }
-    }
-
     &:hover {
       .ac-theme-switch-icon {
         color: var(--ac-primary-hover);
@@ -83,6 +71,14 @@ const { label, class: className } = Astro.props
         color: var(--ac-primary-hover);
       }
     }
+  }
+
+  :global(html[data-theme="dark"]) .ac-theme-switch-icon--light {
+      display: none;
+  }
+
+  :global(html[data-theme="light"]) .ac-theme-switch-icon--dark {
+      display: none;
   }
 
   .ac-theme-switch {
@@ -112,6 +108,13 @@ const { label, class: className } = Astro.props
   }
 </style>
 
+<script is:inline>
+  (function () {
+    const theme = localStorage.getItem('theme') || 'light'
+    document.documentElement.setAttribute('data-theme', theme)
+  })();
+</script>
+
 <script>
   import { DOMLoaded } from '../utils/utils'
 
@@ -121,7 +124,6 @@ const { label, class: className } = Astro.props
     ) as NodeListOf<HTMLInputElement>
 
     const theme = localStorage.getItem('theme') || 'light'
-    document.documentElement.setAttribute('data-theme', theme)
 
     const isLight = theme === 'light'
     themeSwitches.forEach((themeSwitch) => {

--- a/src/components/ThemeSwitch.astro
+++ b/src/components/ThemeSwitch.astro
@@ -109,7 +109,7 @@ const { label, class: className } = Astro.props
 </style>
 
 <script is:inline>
-  (function () {
+  (() => {
     const theme = localStorage.getItem('theme') || 'light'
     document.documentElement.setAttribute('data-theme', theme)
   })();


### PR DESCRIPTION
The current implementation of the ThemeSwitch component has an issue: it waits for the `DOMContentLoaded` event before setting the theme saved in localStorage. This causes two issues:

* A bright flash for split second when the page is already partially displaying, but the event hasn't fired yet.
* The icon for the light theme is displayed for split second before being replaced with the dark theme icon.

This PR does two things:

1. It adds a small inline script that sets the theme saved in localStorage immediately instead of waiting for `DOMContentLoaded`.
2. Hides dark/light theme icons based on `html[data-theme]` instead of `.ac-theme-switch-wrapper:has([aria-checked='true'])`, as those are only set later, on `DOMContentLoaded`.

Presumably, this component is usually located at the very top of the page, so the inline script runs almost immediately, changing the theme, and preventing the background/icon flash.